### PR TITLE
myers/middle_snake: correct safety doc

### DIFF
--- a/src/myers/middle_snake.rs
+++ b/src/myers/middle_snake.rs
@@ -16,7 +16,7 @@ pub struct MiddleSnakeSearch<const BACK: bool> {
 
 impl<const BACK: bool> MiddleSnakeSearch<BACK> {
     /// # Safety
-    /// `data` must be valid for reads between `-file1.len()` and `file2.len()`
+    /// `data` must be valid for reads and writes between `-file2.len() - 1` and `file1.len() + 1`
     pub unsafe fn new(data: NonNull<i32>, file1: &FileSlice, file2: &FileSlice) -> Self {
         let dmin = -(file2.len() as i32);
         let dmax = file1.len() as i32;


### PR DESCRIPTION
Hello, one last thing that my colleague noticed. This PR is assuming that `bounds_check` is correct - I haven't scrutinized the algorithm enough to determine what the exact bounds are.

Again, feel free to change to meet your project's style. (This passes `cargo fmt`, but I don't know how long you prefer your documentation lines to be.)

Commit message follows:

In the documentation for MiddleSnakeSearch::new, the safety constraints described on the `data` pointer do not exactly match how the class uses it. It is stored as the `kvec` field, and looking at the `write_xpos_at_diagonal`, `x_pos_at_diagonal`, and `pos_at_diagonal` functions (a search of `kvec` in the source code revealing that all access to `kvec` go through one of these functions):

- writes could happen, not only reads
- the range of access is as described in the bounds_check function

Therefore, update the documentation accordingly.