### PR TITLE
Update Interner from hashbrown 0.14 to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 ahash = "0.8.0"
-hashbrown = { version = "0.14", default-features = false, features = ["raw", "inline-more"] }
+hashbrown = { version = "0.15", default-features = false, features = ["inline-more"] }
 
 [features]
 default = ["unified_diff"]


### PR DESCRIPTION
Release notes: https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md

`RawTable` is no longer available in this release, in favor of recommending the `HashTable` API instead.