### PR TITLE
Drop aHash dependency in favor of hashbrown's choice of default hasher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "1.65"
+          - "1.71"
           - stable
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "imara-diff"
 version = "0.1.7"
 edition = "2021"
 authors = ["pascalkuthe <pascalkuthe@pm.me>"]
-rust-version = "1.61"
+rust-version = "1.71"
 license = "Apache-2.0"
 
 description = "A high performance library for computing diffs."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ maintenance = { status = "actively-developed" }
 
 
 [dependencies]
-ahash = "0.8.0"
-hashbrown = { version = "0.15", default-features = false, features = ["inline-more"] }
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }
 
 [features]
 default = ["unified_diff"]

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,4 +1,4 @@
-use std::hash::{BuildHasher as _, Hash, Hasher as _};
+use std::hash::{BuildHasher as _, Hash};
 use std::ops::Index;
 
 use hashbrown::hash_table::{Entry, HashTable};
@@ -126,11 +126,11 @@ impl<T: Hash + Eq> Interner<T> {
 
     /// Intern `token` and return a the interned integer
     pub fn intern(&mut self, token: T) -> Token {
-        let hash = hash_one(&self.hasher, &token);
+        let hash = self.hasher.hash_one(&token);
         match self.table.entry(
             hash,
             |&it| self.tokens[it.0 as usize] == token,
-            |&token| hash_one(&self.hasher, &self.tokens[token.0 as usize]),
+            |&token| self.hasher.hash_one(&self.tokens[token.0 as usize]),
         ) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
@@ -155,14 +155,14 @@ impl<T: Hash + Eq> Interner<T> {
         if retained <= erased {
             self.table.clear();
             for (i, token) in self.tokens[0..retained].iter().enumerate() {
-                let hash = hash_one(&self.hasher, &token);
+                let hash = self.hasher.hash_one(token);
                 self.table.insert_unique(hash, Token(i as u32), |&token| {
-                    hash_one(&self.hasher, &self.tokens[token.0 as usize])
+                    self.hasher.hash_one(&self.tokens[token.0 as usize])
                 });
             }
         } else {
             for (i, token) in self.tokens[retained..].iter().enumerate() {
-                let hash = hash_one(&self.hasher, &token);
+                let hash = self.hasher.hash_one(token);
                 match self
                     .table
                     .find_entry(hash, |token| token.0 == (retained + i) as u32)
@@ -181,13 +181,4 @@ impl<T: Hash + Eq> Index<Token> for Interner<T> {
     fn index(&self, index: Token) -> &Self::Output {
         &self.tokens[index.0 as usize]
     }
-}
-
-// TODO: remove in favor of BuildHasher::hash_one once compilers older than 1.71
-// no longer need to be supported.
-// https://doc.rust-lang.org/std/hash/trait.BuildHasher.html#method.hash_one
-fn hash_one<T: Hash>(hasher_parameters: &RandomState, token: &T) -> u64 {
-    let mut hasher = hasher_parameters.build_hasher();
-    token.hash(&mut hasher);
-    hasher.finish()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ mod tests;
 /// `imara-diff` supports multiple different algorithms
 /// for computing an edit sequence.
 /// These algorithms have different performance and all produce different output.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum Algorithm {
     /// A variation of the [`patience` diff algorithm described by Bram Cohen's blog post](https://bramcohen.livejournal.com/73318.html)
     /// that uses a histogram to find the least common LCS.
@@ -199,6 +199,7 @@ pub enum Algorithm {
     /// fallback to Myers algorithm. However this detection has a nontrivial overhead, so
     /// if its known upfront that the sort of tokens is very small `Myers` algorithm should
     /// be used instead.
+    #[default]
     Histogram,
     /// An implementation of the linear space variant of
     /// [Myers  `O((N+M)D)` algorithm](http://www.xmailserver.org/diff2.pdf).
@@ -228,12 +229,6 @@ pub enum Algorithm {
 impl Algorithm {
     #[cfg(test)]
     const ALL: [Self; 2] = [Algorithm::Histogram, Algorithm::Myers];
-}
-
-impl Default for Algorithm {
-    fn default() -> Self {
-        Algorithm::Histogram
-    }
 }
 
 /// Computes an edit-script that transforms `input.before` into `input.after` using

--- a/src/myers/middle_snake.rs
+++ b/src/myers/middle_snake.rs
@@ -245,7 +245,7 @@ impl<const BACK: bool> MiddleSnakeSearch<BACK> {
             k -= 2;
         }
 
-        (best_score > 0).then(|| (best_token_idx1, best_token_idx2))
+        (best_score > 0).then_some((best_token_idx1, best_token_idx2))
     }
 }
 


### PR DESCRIPTION
The `ahash` crate is problematic (https://github.com/tkaitchuck/aHash/issues/238, https://github.com/tkaitchuck/aHash/pull/239, https://github.com/tkaitchuck/aHash/pull/242) and not well maintained.

Since `Interner<T>` has to be able to hash arbitrary token types (everything ranging from long lines of code to individual codepoints, which have pretty different hashing performance characteristics) it is unlikely that any hasher choice made by this crate would be broadly better suitable than the general-purpose fast hasher chosen as default by `hashbrown`.

As a followup to this PR, it might be reasonable to parameterize `Interner` and `InternedInput` with an `S: BuildHasher` type parameter so that downstream code is able to benchmark various different hash implementations based on their own representative data.