### PR TITLE
Delete badges from crates.io metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ exclude = [
     "bench_data",
     "plt.py",
 ]
-[badges]
-maintenance = { status = "actively-developed" }
-
 
 [dependencies]
 ahash = "0.8.0"


### PR DESCRIPTION
The `[badges]` feature in Cargo.toml is obsolete. Crates.io deleted support for badges 4 years ago (https://github.com/rust-lang/crates.io/issues/2436, https://github.com/rust-lang/crates.io/pull/2440, https://github.com/rust-lang/cargo/pull/8727). For a while there was an intention that `maintenance` might continue to be recognized (https://github.com/rust-lang/crates.io/issues/2437, https://github.com/rust-lang/crates.io/issues/2438) but that also was abandoned more than 3 years ago.