### PR TITLE
refactor: drop superfluous trait bounds

### DIFF
--- a/src/intern.rs
+++ b/src/intern.rs
@@ -96,7 +96,7 @@ impl<T: Eq + Hash> InternedInput<T> {
 
 /// An interner that allows for fast access of tokens produced by a [`TokenSource`].
 #[derive(Default)]
-pub struct Interner<T: Hash + Eq> {
+pub struct Interner<T> {
     tokens: Vec<T>,
     table: HashTable<Token>,
     hasher: RandomState,

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -102,7 +102,7 @@ pub struct Interner<T> {
     hasher: RandomState,
 }
 
-impl<T: Hash + Eq> Interner<T> {
+impl<T> Interner<T> {
     /// Create an Interner with an initial capacity calculated by summing the results of calling
     /// [`estimate_tokens`](crate::intern::TokenSource::estimate_tokens) methods of `before` and `after`.
     pub fn new_for_token_source<S: TokenSource<Token = T>>(before: &S, after: &S) -> Self {
@@ -124,6 +124,13 @@ impl<T: Hash + Eq> Interner<T> {
         self.tokens.clear();
     }
 
+    /// Returns to total number of **distinct** tokens currently interned.
+    pub fn num_tokens(&self) -> u32 {
+        self.tokens.len() as u32
+    }
+}
+
+impl<T: Hash + Eq> Interner<T> {
     /// Intern `token` and return a the interned integer.
     pub fn intern(&mut self, token: T) -> Token {
         let hash = self.hasher.hash_one(&token);
@@ -140,11 +147,6 @@ impl<T: Hash + Eq> Interner<T> {
                 interned
             }
         }
-    }
-
-    /// Returns to total number of **distinct** tokens currently interned.
-    pub fn num_tokens(&self) -> u32 {
-        self.tokens.len() as u32
     }
 
     /// Erases `first_erased_token` and any tokens interned afterward from the interner.

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -46,7 +46,7 @@ pub trait TokenSource {
 ///
 /// While you can intern tokens yourself it is strongly recommended to use [`InternedInput`] module.
 #[derive(Default)]
-pub struct InternedInput<T: Eq + Hash> {
+pub struct InternedInput<T> {
     pub before: Vec<Token>,
     pub after: Vec<Token>,
     pub interner: Interner<T>,

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -52,6 +52,14 @@ pub struct InternedInput<T: Eq + Hash> {
     pub interner: Interner<T>,
 }
 
+impl<T> InternedInput<T> {
+    pub fn clear(&mut self) {
+        self.before.clear();
+        self.after.clear();
+        self.interner.clear();
+    }
+}
+
 impl<T: Eq + Hash> InternedInput<T> {
     pub fn new<I: TokenSource<Token = T>>(before: I, after: I) -> Self {
         let token_estimate_before = before.estimate_tokens() as usize;
@@ -85,12 +93,6 @@ impl<T: Eq + Hash> InternedInput<T> {
         self.after.clear();
         self.after
             .extend(input.map(|token| self.interner.intern(token)));
-    }
-
-    pub fn clear(&mut self) {
-        self.before.clear();
-        self.after.clear();
-        self.interner.clear();
     }
 }
 
@@ -178,7 +180,7 @@ impl<T: Hash + Eq> Interner<T> {
     }
 }
 
-impl<T: Hash + Eq> Index<Token> for Interner<T> {
+impl<T> Index<Token> for Interner<T> {
     type Output = T;
     fn index(&self, index: Token) -> &Self::Output {
         &self.tokens[index.0 as usize]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,6 @@
 //! assert_eq!(changes.removals, 1);
 //! ```
 
-use std::hash::Hash;
-
 #[cfg(feature = "unified_diff")]
 pub use unified_diff::UnifiedDiffBuilder;
 
@@ -234,11 +232,7 @@ impl Algorithm {
 /// Computes an edit-script that transforms `input.before` into `input.after` using
 /// the specified `algorithm`
 /// The edit-script is passed to `sink.process_change` while it is produced.
-pub fn diff<S: Sink, T: Eq + Hash>(
-    algorithm: Algorithm,
-    input: &InternedInput<T>,
-    sink: S,
-) -> S::Out {
+pub fn diff<S: Sink, T>(algorithm: Algorithm, input: &InternedInput<T>, sink: S) -> S::Out {
     diff_with_tokens(
         algorithm,
         &input.before,

--- a/src/unified_diff.rs
+++ b/src/unified_diff.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Display, Write};
-use std::hash::Hash;
 use std::ops::Range;
 
 use crate::intern::{InternedInput, Interner, Token};
@@ -10,7 +9,7 @@ use crate::Sink;
 pub struct UnifiedDiffBuilder<'a, W, T>
 where
     W: Write,
-    T: Hash + Eq + Display,
+    T: Display,
 {
     before: &'a [Token],
     after: &'a [Token],
@@ -28,7 +27,7 @@ where
 
 impl<'a, T> UnifiedDiffBuilder<'a, String, T>
 where
-    T: Hash + Eq + Display,
+    T: Display,
 {
     /// Create a new `UnifiedDiffBuilder` for the given `input`,
     /// that will return a [`String`].
@@ -51,7 +50,7 @@ where
 impl<'a, W, T> UnifiedDiffBuilder<'a, W, T>
 where
     W: Write,
-    T: Hash + Eq + Display,
+    T: Display,
 {
     /// Create a new `UnifiedDiffBuilder` for the given `input`,
     /// that will writes it output to the provided implementation of [`Write`].
@@ -111,7 +110,7 @@ where
 impl<W, T> Sink for UnifiedDiffBuilder<'_, W, T>
 where
     W: Write,
-    T: Hash + Eq + Display,
+    T: Display,
 {
     type Out = W;
 


### PR DESCRIPTION
As explained in the first commit, it's recommended to avoid putting trait bounds in structs, since causes the bounds to be propagated across the codebase for no added benefit.