### PR TITLE
Use an explicit lifetime parameter for clarity

### DIFF
--- a/src/myers/slice.rs
+++ b/src/myers/slice.rs
@@ -27,7 +27,7 @@ impl<'a> FileSlice<'a> {
         }
     }
 
-    pub fn borrow(&mut self) -> FileSlice {
+    pub fn borrow(&mut self) -> FileSlice<'_> {
         FileSlice {
             tokens: self.tokens,
             changed: self.changed,


### PR DESCRIPTION
Seems pretty obvious that this was the intended interpretation. The only two possible options are `fn borrow(&mut self) -> FileSlice<'_>` and `fn borrow(&'a mut self) -> FileSlice<'a>`, and the latter breaks a bunch of existing code, so it seems pretty obvious that the existing implementation (that implied the first meaning) wasn’t a mistake.