### PR TITLE
Fix unified diff including up to `2 * context_lines` before first hunk when near input start

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -203,6 +203,58 @@ fn simple_insert() {
     }
 }
 
+#[test]
+fn unified_diff_context_lines_near_input_start_and_end() {
+    let before = r#"a
+b
+c
+d
+e
+f
+g
+h
+i
+"#;
+
+    let after = r#"a
+b
+c
+d
+edit
+f
+g
+h
+i
+"#;
+
+    let input = InternedInput::new(before, after);
+    for algorithm in Algorithm::ALL {
+        println!("{algorithm:?}");
+        let mut diff = Diff::compute(algorithm, &input);
+        diff.postprocess_lines(&input);
+        expect![[r#"
+          @@ -2,7 +2,7 @@
+           b
+           c
+           d
+          -e
+          +edit
+           f
+           g
+           h
+          "#]]
+        .assert_eq(
+            &diff
+                .unified_diff(
+                    &BasicLineDiffPrinter(&input.interner),
+                    UnifiedDiffConfig::default(),
+                    &input,
+                )
+                .to_string(),
+        );
+    }
+}
+
 pub fn project_root() -> PathBuf {
     let dir = env!("CARGO_MANIFEST_DIR");
     let mut res = PathBuf::from(dir);

--- a/src/unified_diff.rs
+++ b/src/unified_diff.rs
@@ -143,18 +143,18 @@ pub struct UnifiedDiff<'a, P: UnifiedDiffPrinter> {
 
 impl<P: UnifiedDiffPrinter> Display for UnifiedDiff<'_, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut pos = 0;
-        let mut before_context_len = 0;
-        let mut after_context_len = 0;
         let first_hunk = self.diff.hunks().next().unwrap_or_default();
-        let mut before_context_start = first_hunk
+        let mut pos = first_hunk
             .before
             .start
             .saturating_sub(self.config.context_len);
+        let mut before_context_start = pos;
         let mut after_context_start = first_hunk
             .after
             .start
             .saturating_sub(self.config.context_len);
+        let mut before_context_len = 0;
+        let mut after_context_len = 0;
         let mut buffer = String::new();
         for hunk in self.diff.hunks() {
             if hunk.before.start - pos > 2 * self.config.context_len {


### PR DESCRIPTION
The bug is that when the first hunk start line is `> context_lines` and `<= 2 * context_lines`, all the lines before the hunk are included in the context.

This fixes the behavior to be the same as `diff -u`:

```bash
printf "a\nb\nc\nd\ne\nf\ng\nh\ni" > input1
printf "a\nb\nc\nd\nedit\nf\ng\nh\ni" > input2
diff -u input1 input2
```

```
@@ -2,7 +2,7 @@
 b
 c
 d
-e
+edit
 f
 g
 h
```

This came up in Zed when optimizing diffing in a case where the edited lines are known.  These edited regions are then provided to imara-diff.  Often this works perfectly, but when the first diff is not immediately after the context lines this bug occurs and causes extra prefix context lines to appear.

I realize that only diffing these edited regions will not always match a full input diff, but for this particular use-case it is preferable :)