### PR TITLE
Bound common-line pruning to the local window

### DIFF
--- a/src/myers/preprocess.rs
+++ b/src/myers/preprocess.rs
@@ -135,7 +135,7 @@ fn should_prune_common_line(token_status: &[Occurrences], pos: usize) -> bool {
     let mut unmatched_before = 0;
     let mut common_before = 0;
 
-    let start = if pos > WINDOW_SIZE { WINDOW_SIZE } else { 0 };
+    let start = pos.saturating_sub(WINDOW_SIZE);
     for status in token_status[start..pos].iter().rev() {
         match status {
             Occurrences::None => {
@@ -175,4 +175,24 @@ fn should_prune_common_line(token_status: &[Occurrences], pos: usize) -> bool {
     let unmatched = unmatched_before + unmatched_after;
 
     unmatched > 3 * common
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_prune_common_line, Occurrences};
+
+    #[test]
+    fn common_line_pruning_ignores_distant_context() {
+        let mut token_status = vec![Occurrences::Some; 700];
+        token_status[100..400].fill(Occurrences::None);
+        token_status[400..450].fill(Occurrences::None);
+        token_status[450..500].fill(Occurrences::Common);
+        token_status[500..550].fill(Occurrences::Common);
+        token_status[550..600].fill(Occurrences::None);
+
+        assert!(
+            !should_prune_common_line(&token_status, 500),
+            "only the last 100 items before the current line should contribute to the backward scan"
+        );
+    }
 }

--- a/src/myers/slice.rs
+++ b/src/myers/slice.rs
@@ -27,7 +27,7 @@ impl<'a> FileSlice<'a> {
         }
     }
 
-    pub fn borrow(&'_ mut self) -> FileSlice<'_> {
+    pub fn borrow(&mut self) -> FileSlice<'_> {
         FileSlice {
             tokens: self.tokens,
             changed: self.changed,


### PR DESCRIPTION
This PR fixes a performance regression. I validated the work done by Codex, also by running the Gitoxide test-suite against it. It's not the largest in the world for diffing, but it's something.

### Test Results

  - Unfixed 0.1.8: 24.19s
  - Fixed 0.1.x: 0.15s

### Tasks

* [x] human review
* [x] fix clippy because it's a good time to do that now

----

Fix should_prune_common_line() so the backward scan starts at pos.saturating_sub(WINDOW_SIZE) instead of the absolute WINDOW_SIZE index.

The old bound made the scanned range grow with pos, which turned the preprocessing heuristic into an increasingly expensive rescan on highly repetitive inputs and caused the gix-merge clusterfuzz testcase to time out.

Add a regression test that proves distant context outside the local window does not affect the pruning decision.

